### PR TITLE
Add version strings to client initialization

### DIFF
--- a/.changeset/curly-cups-provide.md
+++ b/.changeset/curly-cups-provide.md
@@ -1,0 +1,5 @@
+---
+"medusajs-payment-mollie": patch
+---
+
+Added User Agent information

--- a/packages/core/mollie-base.ts
+++ b/packages/core/mollie-base.ts
@@ -75,6 +75,7 @@ class MollieBase extends AbstractPaymentProvider<MollieOptions> {
     /// init mollieClient
     this.mollieClient = MollieClientProvider({
       apiKey: options.apiKey,
+      versionStrings: "MedusaJS/1.0.0 BashirUddin/" + process.env.npm_package_version, // todo ideally determine Medusa version dynamically
     });
   }
 


### PR DESCRIPTION
We use this to track utilization of packages in our ecosystem. This addition would be extremely helpful. 